### PR TITLE
Fix Bokeh version number to 0.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh
+bokeh==0.10.0
 numpy
 webassets
 pandas


### PR DESCRIPTION
Bokeh as deprecated `_legacy_charts` in the latest `0.11.0` release, this PR specifies the version number to `0.10.0`. As a longer term solution we need to replace `_legacy_charts` with new `bokeh.charts`. http://bokeh.pydata.org/en/latest/docs/releases/0.11.0.html#migration-guide
